### PR TITLE
fix bug when click " . " button

### DIFF
--- a/src/constants/Reducers.js
+++ b/src/constants/Reducers.js
@@ -1,14 +1,16 @@
 const Reducers = {
     addDigit: (state, digit) => {
-        if (digit === "0" && state.currentOperand === "0")
+        const currentOperand = state.currentOperand ?? "";
+        
+        if (digit === "0" && currentOperand === "0")
             return state;
-        if (digit === "." && state.currentOperand.includes("."))
+        if (digit === ".") {
+            if (!currentOperand || currentOperand.includes("."))
             return state;
+        }
 
         if (state.overwrite)
             return { ...state, currentOperand: digit, overwrite: false };
-
-        const currentOperand = state.currentOperand ?? "";
 
         return { ...state, currentOperand: currentOperand + digit };
     },


### PR DESCRIPTION
Click " . " when currentOperand === null (ex: click it at the start) will make the app crash. So I give currentOperand a default value before doing any check.